### PR TITLE
Update color scheme in custom base SCSS with deep blue palette

### DIFF
--- a/src/assets/scss/libs/_customBase.scss
+++ b/src/assets/scss/libs/_customBase.scss
@@ -47,7 +47,7 @@ a {
 
     h2 {
         color: #333;
-        border-bottom: 2px solid #007bff;
+        border-bottom: 2px solid #08033d;
         padding-bottom: 0.5rem;
         margin-bottom: 1.5rem;
     }
@@ -56,7 +56,7 @@ a {
         color: #444;
         margin: 2rem 0 1rem;
         padding-left: 0.5rem;
-        border-left: 4px solid #007bff;
+        border-left: 4px solid #08033d;
     }
 
     h4 {
@@ -78,7 +78,7 @@ a {
                 background: #f8f9fa;
                 padding: 0.75rem;
                 border-radius: 4px;
-                border-left: 3px solid #007bff;
+                border-left: 3px solid #08033d;
             }
         }
     }
@@ -104,14 +104,14 @@ a {
     .contact-link {
         display: inline-block;
         padding: 0.5rem 1rem;
-        background: #007bff;
+        background: #08033d;
         color: white;
         text-decoration: none;
         border-radius: 4px;
         margin-top: 1rem;
 
         &:hover {
-            background: #0056b3;
+            background: #110766;
         }
     }
 


### PR DESCRIPTION
- Replace #007bff with #08033d for headings, borders, and contact link
- Adjust hover state background to #110766
- Maintain consistent styling while introducing a more distinctive color theme