### PR TITLE
GitHub Actionsのデプロイメントを統合し、peaceiris/actions-gh-pagesを使用してGitHub Page…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,17 +7,18 @@ on:
   workflow_dispatch:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     
     permissions:
       contents: read
+      pages: write
+      actions: write
     
     steps:
       - name: Checkout
@@ -38,31 +39,20 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
           QIITA_API_TOKEN: ${{ secrets.QIITA_API_TOKEN }}
 
-      - name: Upload build artifacts
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: public
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    
-    permissions:
-      pages: write
-      id-token: write
-    
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy from ${{ github.sha }}'
 
   lighthouse:
     runs-on: ubuntu-latest
-    needs: deploy
+    needs: build-and-deploy
     if: github.ref == 'refs/heads/master'
     
     permissions:
@@ -74,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Wait for deployment
-        run: sleep 30
+        run: sleep 60
 
       - name: Lighthouse CI
         uses: treosh/lighthouse-ci-action@v11

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -20,9 +20,6 @@ jobs:
       pages: write
       id-token: write
     
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
       - name: Checkout
@@ -55,16 +52,17 @@ jobs:
             echo "changes=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Upload build artifacts
-        if: steps.check-changes.outputs.changes == 'true'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: public
-
       - name: Deploy to GitHub Pages
         if: steps.check-changes.outputs.changes == 'true'
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Scheduled update from ${{ github.sha }}'
 
       - name: Notification
         if: steps.check-changes.outputs.changes == 'true'


### PR DESCRIPTION
…sにデプロイするように更新。デプロイメントの待機時間を60秒に延長。